### PR TITLE
Allow end-users to select specific versions of vendored packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
   * heroku-sendgrid now pulls name/email from wpdb instead of heroku config
     EMAIL_REPLY_TO, EMAIL_FROM, and EMAIL_NAME are deprecated
+  * End-users can now choose versions for vendored apps. Refer to VERSIONS.md.
 
 v0.7
 

--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ Clone the repository.
 $ git clone git://github.com/username/wordpress-on-heroku.git myblog
 ```
 
-Create the app on Heroku.
+Create Wordpress on Heroku.
 ```bash
 $ cd myblog
 $ heroku create -s cedar
@@ -102,6 +102,15 @@ Finally, enabling and configuring the following Wordpress plugins will also spee
 
 ## Usage
 
+### Creating your Wordpress site on Heroku
+```bash
+$ git clone git://github.com/username/wordpress-on-heroku.git myblog
+$ cd myblog
+$ heroku create -s cedar
+$ heroku config:add BUILDPACK_URL=https://github.com/mchung/heroku-buildpack-wordpress.git
+$ git push heroku master
+```
+
 ### Adding a custom domain name
 ```bash
 $ heroku domains:add marcchung.org
@@ -160,6 +169,10 @@ $ heroku config:set SYSTEM_USERNAME=admin
 $ heroku config:set SYSTEM_PASSWORD=secret123
 # Visit /apc.php or /phpinfo.php
 ```
+
+### Choosing specific versions of vendored packages
+
+See [VERSIONS](VERSIONS.md) for how to pick specific versions of Nginx, PHP, and Wordpress
 
 ### Workflow (optional)
 
@@ -253,7 +266,6 @@ Not comfortable downloading and running a copy of someone else's PHP or Nginx ex
 
 ## TODO
 
-* Automate vendor upgrades. Make it easy to keep in sync with latest Nginx, PHP, and Wordpress.
 * End-users shouldn't be able to do things that aren't supported on Heroku. Write plugins to hide everything.
 * Integrate New Relic.
 * CDN support.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,32 @@
+Here's a list of vendored Nginx and PHP packages made available by this buildpack.  They are hosted on S3 and maintained by @mchung.
+
+Nginx
+* 1.5.0 (development)
+* 1.4.1 (stable)
+* 1.3.12 (development)
+* 1.3.11 (development)
+* 1.2.7 (stable)
+
+PHP
+* 5.4.11 (5.4-stable)
+* 5.3.9 (5.3-stable)
+
+Wordpress (downloaded directly from [Wordpress](http://wordpress.org/download/release-archive/)
+* 3.5.1
+* 3.5.0
+
+Here's how to configure Wordpress on Heroku to use specific versions of Nginx and PHP:
+
+```bash
+$ git clone git://github.com/mchung/wordpress-on-heroku.git custom-wp
+$ cd custom-wp
+$ heroku create -s cedar
+$ heroku labs:enable user-env-compile
+$ heroku config:set NGINX_VERSION=1.5.0
+$ heroku config:set PHP_VERSION=5.4.11
+$ heroku config:set WORDPRESS_VERSION=3.5.1
+$ heroku config:set BUILDPACK_URL=https://github.com/mchung/heroku-buildpack-wordpress.git
+$ git push heroku master
+```
+
+To request a new vendored package, [please file an issue](https://github.com/mchung/heroku-buildpack-wordpress/issues/new?title=Request%20for%20new%20vendor%20package&body=Hi-%0A%0APlease add:%0A%0A```%0Anginx-2.3.18%0Aphp-4.5%0A```%0A%0AThank%20you)

--- a/bin/compile
+++ b/bin/compile
@@ -5,10 +5,27 @@ set -e
 set -o pipefail
 
 # START CONFIG
-NGINX_VERSION=1.3.11
-PHP_VERSION=5.4.11
-WORDPRESS_VERSION=3.5.1
-S3_BUCKET=heroku-buildpack-wordpress
+
+# Support end-user configured NGINX_VERSION, PHP_VERSION, WORDPRESS_VERSION
+# and S3_BUCKET environment variables. This way, end-users can choose exactly
+# which versions to run with. Requires user-env-compile.
+
+if [ -z "$NGINX_VERSION" ]; then
+  NGINX_VERSION=1.4.1
+fi
+
+if [ -z "$PHP_VERSION" ]; then
+  PHP_VERSION=5.4.11
+fi
+
+if [ -z "$WORDPRESS_VERSION" ]; then
+  WORDPRESS_VERSION=3.5.1
+fi
+
+if [ -z "$S3_BUCKET" ]; then
+  S3_BUCKET=heroku-buildpack-wordpress
+fi
+
 # END CONFIG
 
 #


### PR DESCRIPTION
Heroku has an experimental labs feature called user-env-compile that exposes an app's config vars during slug compilation.

This means that an end-user of this buildpack can choose which versions of PHP and Nginx to deploy along side Wordpress. 

This pull request updates bin/compile to use versions declared by the environment (set with heroku config:set) instead of the versions declared by the buildpack.
