### PR TITLE
fix cron.sh path in documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -152,7 +152,7 @@ Heroku allows you to trigger wp-cron from their scheduler.
 $ heroku addons:add scheduler:standard
 
 # Visit the Heroku scheduler dashboard and add a new task:
-./cron.sh
+./bin/cron.sh
 ```
 
 Alternatively, you may also re-enable wp-cron.


### PR DESCRIPTION
Fix for:

app[scheduler.xxxx]: bash: ./cron.sh: No such file or directory
