### PR TITLE
User env compile deprecated soon, keep env available for bin/compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,6 @@ export_env_dir() {
   env_dir=$1
   if [ -d "$env_dir" ]; then
     for e in $(ls $env_dir); do
-      echo "$e" &&
       export "$e=$(cat $env_dir/$e)"
       :
     done


### PR DESCRIPTION
Heroku gave a heads up that user-env-compile will be deprecated in the following weeks. The env will be available in a directory and the directory will be given as a parameter for bin/compile.

This pull request keeps the env available after those Heroku changes. You can test this with

```
    heroku labs:enable buildpack-env-arg
    heroku labs:disable user-env-compile
```

After Heroku has made the changes enabling buildpack-env-arg is not needed, this is just for testing.
