### PR TITLE
Add WORDPRESS_HOST heroku config var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 master
+  * Added WORDPRESS_HOST config var which defaults to 'wordpress.org'. This 
+    comes in handy if you want to download Wordpress in a different language, 
+    e.g. 'de.wordpress.org'.
   * heroku-sendgrid now pulls name/email from wpdb instead of heroku config
     EMAIL_REPLY_TO, EMAIL_FROM, and EMAIL_NAME are deprecated
   * End-users can now choose versions for vendored apps. Refer to VERSIONS.md.

--- a/README.markdown
+++ b/README.markdown
@@ -83,7 +83,7 @@ A few Wordpress environment variables can be controlled via Heroku using `heroku
 * `WP_CACHE`
 * `DISABLE_WP_CRON`
 * `WORDPRESS_DIR`, see [Specifying WordPress installation directory](#specifying-wordpress-installation-directory)
-* `WORDPRESS_VERSION`, see [VERSIONS](VERSIONS.md)
+* `WORDPRESS_VERSION` and `WORDPRESS_HOST`, see [VERSIONS](VERSIONS.md)
 
 > To add a Heroku environment variable: `heroku config:set GOOG_UA_ID=UA=1234777-9`
 
@@ -295,6 +295,7 @@ Not comfortable downloading and running a copy of someone else's PHP or Nginx ex
 * Marc Chung - Follow [@mchung](https://github.com/mchung) on GitHub and also [@heisenthought](https://twitter.com/heisenthought) on Twitter
 * Oskari Okko Ojala - [@okko](https://github.com/okko) on GitHub, [@okko](https://twitter.com/okko) on Twitter
 * Luis Herranz - [@LuisHerranz](https://github.com/LuisHerranz) on Github, [@luisherranz](https://twitter.com/luisherranz) on Twitter
+* Martin Andert - [@martinandert](https://github.com/martinandert) on Github
 
 ## Thanks
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -45,6 +45,13 @@ $ heroku config:set WORDPRESS_VERSION=3.6.2
 $ git push heroku master
 ```
 
+Configure Wordpress on Heroku to use a specific language and version of Wordpress
+```bash
+$ heroku config:set WORDPRESS_HOST=de.wordpress.org
+$ heroku config:set WORDPRESS_VERSION=3.9.1-de_DE
+```
+This will download Wordpress from http://de.wordpress.org/wordpress-3.9.1-de_DE.tar.gz
+
 To request a new vendored package, [please file an issue](https://github.com/mchung/heroku-buildpack-wordpress/issues/new?title=Request%20for%20new%20vendor%20package&body=Hi-%0A%0APlease add:%0A%0A```%0Anginx-2.3.18%0Aphp-4.5%0A```%0A%0AThank%20you)
 Note that WordPress does not need to be vendored, you can set the WORDPRESS_VERSION to install any version of WordPress.
 

--- a/bin/compile
+++ b/bin/compile
@@ -36,6 +36,10 @@ if [ -z "$WORDPRESS_VERSION" ]; then
   WORDPRESS_VERSION=3.9.1
 fi
 
+if [ -z "$WORDPRESS_HOST" ]; then
+  WORDPRESS_HOST=wordpress.org
+fi
+
 if [ -z "$S3_BUCKET" ]; then
   S3_BUCKET=heroku-buildpack-wordpress
 fi
@@ -45,7 +49,7 @@ fi
 #
 NGINX_URL="https://s3.amazonaws.com/${S3_BUCKET}/nginx-${NGINX_VERSION}-heroku.tar.gz"
 PHP_URL="https://s3.amazonaws.com/${S3_BUCKET}/php-${PHP_VERSION}-with-fpm-heroku.tar.gz"
-WORDPRESS_URL="http://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz"
+WORDPRESS_URL="http://${WORDPRESS_HOST}/wordpress-${WORDPRESS_VERSION}.tar.gz"
 #
 
 function indent() {


### PR DESCRIPTION
This, together with WORDPRESS_VERSION, allows the buildpack to download a pre-localized Wordpress version. The default setting for WORDPRESS_HOST is "wordpress.org".

Example:

``` bash
heroku config:set WORDPRESS_HOST=de.wordpress.org
heroku config:set WORDPRESS_VERSION=3.9.1-de_DE
```

This will download Wordpress from http://de.wordpress.org/wordpress-3.9.1-de_DE.tar.gz
